### PR TITLE
Don't handleScroll after component has unmounted

### DIFF
--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -36,15 +36,18 @@ export default class ScrollAnimation extends Component {
       elementTop: this.node.getBoundingClientRect().top + ScrollAnimation.posTop()
     }, this.handleScroll);
     this.handleScroll();
+    this.isMounted = true;
   }
 
   componentWillUnmount() {
     if (window && window.addEventListener) {
       window.removeEventListener("scroll", this.listener);
     }
+    this.isMounted = false;
   }
 
   handleScroll() {
+    if (!this.isMounted) return;
     const visible = this.isVisible();
     if (!visible.partially) {
       this.state.timeouts.forEach(function (tid) {


### PR DESCRIPTION
`handleScroll` is throttled by 200ms, so it's often the case that the listener gets fired after the component has already unmounted and removed the listener. Adding this guard clause protects against this.